### PR TITLE
Fixes required for Jupyter Notebooks conversion to PDF

### DIFF
--- a/cours/04-fonctions/homework-02.ipynb
+++ b/cours/04-fonctions/homework-02.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "![Entête CCI](./assets/entete-cci.png)\n",
     "\n",
@@ -19,12 +20,13 @@
     "## Exerice 1 - Attraper les insectes (6 points)\n",
     "\n",
     "Le programme suivant est mal écrit et comporte des bugs :"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from math import sqrt\n",
     "def foo  (var1, var2,var3, var4, var5,      var6)                                          :\n",
@@ -37,28 +39,27 @@
     "    - x_1 * z_2,\n",
     "        x_1 * y_2-y_1                                                        *  \n",
     "         x_2)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Ecrivez votre propre version documentée et corrigée de ce programme :"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Ecrivez ici un programme propre, élégant et documenté"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Exercice 2 - Tri avec un alphabet réduit (4 points)\n",
     "\n",
@@ -69,10 +70,12 @@
     "En revanche, cet algorithme peut être utilisé pour trier l'ensemble des lettres de l'alphabet, qui comporte uniquement 26 lettres.\n",
     "\n",
     "L'algorithme de tri sur un ensemble fini consiste en les étapes suivantes :\n",
-    "* Parcourir les entrées et les compter.\n",
-    "* Pour chaque élément dans l'ordre choisi, le renvoyer le nombre de fois compté.\n",
+    "\n",
+    "- Parcourir les entrées et les compter.\n",
+    "- Pour chaque élément dans l'ordre choisi, le renvoyer le nombre de fois compté.\n",
     "\n",
     "Ainsi, pour la chaîne de caractères : `\"au clair de la lune\"`, on obtient à la fin de la 1ière étape :\n",
+    "\n",
     "- a : 3\n",
     "- b : 0\n",
     "- c : 1\n",
@@ -103,30 +106,31 @@
     "Il ne reste plus qu'à afficher chaque caractère le nombre de fois indiqué : `\"aaacdeeilllnruu\"`.\n",
     "\n",
     "L'ADN est structué en 2 brins enroulés en double hélice. Chaque brin est composée de nucléotides, lesquels sont formés d'une base nucléique. Une base nucléique peut être :\n",
-    "* A : Adénine,\n",
-    "* C : Cytosine,\n",
-    "* G : Guanine,\n",
-    "* T : Thymine.\n",
+    "\n",
+    "- A : Adénine,\n",
+    "- C : Cytosine,\n",
+    "- G : Guanine,\n",
+    "- T : Thymine.\n",
     "\n",
     "On peut donc représenter un brin d'ADN avec un alphabet réduit de la manière suivante : `\"AGTTACGTGAACCCGTTGGAA\"`.\n",
     "\n",
     "Ecrivez une fonction qui trie les bases nucléiques d'un brin d'ADN."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def tri_adn(adn):\n",
     "    \"\"\"Tri la chaine de caracteres adn composee des caracteres A, C, G, et T.\"\"\"\n",
     "    pass"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Par exemple :\n",
     "```python\n",
@@ -137,21 +141,21 @@
     "```\n",
     "AACCGGTT\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Exercice 3 - Dérivée d'une fonction polynomiale (6 points)\n",
     "\n",
     "Pour rappel, une fonction polynomiale est de la forme :\n",
     "\n",
     "$$\n",
-    "\\begin{align}\n",
-    "f(x) & = a_n x^n + a_{n-1}x^{n-1} + \\dotsb + a_2 x^2 + a_1 x + a_0 \\\\[6mu]\n",
-    "     & = \\sum_{k=0}^n a_k x^k\n",
-    "\\end{align}\n",
+    "\\begin{aligned}\n",
+    "f(x) &= a_n x^n + a_{n-1}x^{n-1} + \\dotsb + a_2 x^2 + a_1 x + a_0 \\\\[1em]\n",
+    "     &= \\sum_{k=0}^n a_k x^k\n",
+    "\\end{aligned}\n",
     "$$\n",
     "\n",
     "Sachant que l'on calcule la dérivée d'une puissance ainsi :\n",
@@ -186,12 +190,13 @@
     "```\n",
     "3 * (x**4) + 2 * (x**3) + 5 * x + 4\n",
     "```\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def affiche_polynome(*args):\n",
     "    \"\"\"Affiche un polynome de rangs (ak, k) au format Python.\"\"\"\n",
@@ -201,12 +206,11 @@
     "        pass\n",
     "\n",
     "    print(resultat)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Ecrivez maintenant une fonction qui affiche la dérivée d'un polynôme, au même format.\n",
     "\n",
@@ -219,12 +223,13 @@
     "```\n",
     "12 * (x**3) + 6 * (x**2) + 5\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def derive_polynome(*args):\n",
     "    \"\"\"Affiche la derivee d'un polynome de rangs (ak, k) au format Python.\"\"\"\n",
@@ -234,41 +239,40 @@
     "        pass\n",
     "\n",
     "    print(resultat)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Sachant que Python permet l'évaluation d'une chaîne de caractères de la manière suivante :"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "f = \"(x**2) + 5 * x + 5\"\n",
-    "x = 2\n",
-    "eval(f)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "19"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "f = \"(x**2) + 5 * x + 5\"\n",
+    "x = 2\n",
+    "eval(f)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Ecrivez une fonction `evalue_derivee_polynome` qui, à l'aide de `derive_polynome`, évalue la dérivée pour une valeur x donnée.\n",
     "\n",
@@ -281,22 +285,22 @@
     "```\n",
     "125\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def evalue_derivee_polynome(x, *args):\n",
     "    \"\"\"Evalue la derivee d'un polynome pour la valeur x.\"\"\"\n",
     "    pass"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Exercice 4 - Fibonacci (4 points)\n",
     "\n",
@@ -315,62 +319,61 @@
     "$$\n",
     "\n",
     "Ecrivez une fonction utilisant une boucle qui calcule et affiche les $n$ premiers nombres de Fibonacci."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def fibonacci(n):\n",
     "    \"\"\"Calcule et affiche les n premiers nombres de Fibonacci.\"\"\"\n",
     "    pass"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Pour rappel, une fonction récursive est une fonction qui s'appelle elle-même.\n",
     "\n",
     "Ecrivez une fonction `fib` utilisant la récursion pour calculer le `n`ième nombre de Fibonacci."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def fib(n):\n",
     "    \"\"\"Calcule recursivement le n ieme nombre de Fibonacci.\"\"\"\n",
     "    pass"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
-  "orig_nbformat": 4,
+  "interpreter": {
+   "hash": "36cf16204b8548560b1c020c4e8fb5b57f0e4c58016f52f2d4be01e192833930"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 64-bit",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python",
-   "version": "3.9.7",
-   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "pygments_lexer": "ipython3",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
    "nbconvert_exporter": "python",
-   "file_extension": ".py"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.9.7 64-bit"
-  },
-  "interpreter": {
-   "hash": "36cf16204b8548560b1c020c4e8fb5b57f0e4c58016f52f2d4be01e192833930"
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/cours/04-fonctions/work-assignment-08.md
+++ b/cours/04-fonctions/work-assignment-08.md
@@ -117,8 +117,8 @@ On peut calculer le cosinus de `x` à l'aide d'une série infinie :
 
 $$
 \begin{aligned}
-\cos x & = 1 - \frac{x^2}{2!} + \frac{x^4}{4!} - \frac{x^6}{6!} + \cdots \\[6mu]
-       & = \sum_{n=0}^\infty \frac{(-1)^n x^{2n}}{(2n)!}
+\cos x &= 1 - \frac{x^2}{2!} + \frac{x^4}{4!} - \frac{x^6}{6!} + \cdots \\[1em]
+       &= \sum_{n=0}^\infty \frac{(-1)^n x^{2n}}{(2n)!}
 \end{aligned}
 $$
 
@@ -264,33 +264,33 @@ y_2 \\
 z_2
 \end{pmatrix}
 ,
-PS & = \overrightarrow{V_1} \cdot \overrightarrow{V_2} \\[6mu]
-   & = \frac{1}{2} \left( 
+PS &= \overrightarrow{V_1} \cdot \overrightarrow{V_2} \\[1em]
+   &= \frac{1}{2} \left( 
             \left| \overrightarrow{V_1} + \overrightarrow{V_2} \right|^2 
           - \left| \overrightarrow{V_1} \right|^2 
           - \left| \overrightarrow{V_2} \right|^2  
-       \right) \\[6mu]
-   & = \frac{1}{2} \left(
+       \right) \\[1em]
+   &= \frac{1}{2} \left(
             \left( \sqrt{(x_1 + x_2)^2 + (y_1 + y_2)^2 + (z_1 + z_2)^2}^2 \right)
           - \left( \sqrt{x_1^2 + y_1^2 + z_1^2}^2 \right)
           - \left( \sqrt{x_2^2 + y_2^2 + z_2^2}^2 \right)
-        \right) \\[6mu]
-   & = \frac{1}{2} \left(
+        \right) \\[1em]
+   &= \frac{1}{2} \left(
             \left( (x_1 + x_2)^2 + (y_1 + y_2)^2 + (z_1 + z_2)^2 \right)
           - \left( x_1^2 + y_1^2 + z_1^2 \right)
           - \left( x_2^2 + y_2^2 + z_2^2 \right)
-        \right) \\[6mu]
-   & = \frac{1}{2} \left(
+        \right) \\[1em]
+   &= \frac{1}{2} \left(
             (x_1 + x_2)^2 + (y_1 + y_2)^2 + (z_1 + z_2)^2
           - x_1^2 - y_1^2 - z_1^2
           - x_2^2 - y_2^2 - z_2^2
-        \right) \\[6mu]
-   & = \frac{1}{2} \left(
+        \right) \\[1em]
+   &= \frac{1}{2} \left(
             2 x_1 x_2
           + 2 y_1 y_2
           + 2 z_1 z_2
-        \right) \\[6mu]
-   & = x_1 x_2 + y_1 y_2 + z_1 z_2
+        \right) \\[1em]
+   &= x_1 x_2 + y_1 y_2 + z_1 z_2
 \end{aligned}
 $$
 
@@ -326,8 +326,8 @@ y_2 \\
 z_2
 \end{pmatrix}
 ,
-PV & = \overrightarrow{V_1} \wedge \overrightarrow{V_2} \\[6mu]
-   & = \begin{pmatrix}
+PV &= \overrightarrow{V_1} \wedge \overrightarrow{V_2} \\[1em]
+   &= \begin{pmatrix}
             y_1 z_2 - z_1 y_2 \\
             z_1 x_2 - x_1 z_2 \\
             x_1 y_2 - y_1 x_2
@@ -487,12 +487,12 @@ On obtient donc directement la distance :
 $$
 \begin{aligned}
 \overrightarrow{OK} \cdot \overrightarrow{OC} 
-    & = \left| \overrightarrow{OK} \right| \times \left| \overrightarrow{OH} \right| \\[6mu]
+    &= \left| \overrightarrow{OK} \right| \times \left| \overrightarrow{OH} \right| \\[1em]
 \vec{k} \cdot \overrightarrow{OC_S}
-    & = \left| \vec{k} \right| \times \left| \overrightarrow{OH} \right| \\[6mu]
+    &= \left| \vec{k} \right| \times \left| \overrightarrow{OH} \right| \\[1em]
 \vec{k} \cdot \overrightarrow{AC_S}
-    & = 1 \times \left| \overrightarrow{OH} \right| \\[6mu]
-\left| \overrightarrow{OH} \right| & = \vec{k} \cdot \overrightarrow{AC_S}
+    &= 1 \times \left| \overrightarrow{OH} \right| \\[1em]
+\left| \overrightarrow{OH} \right| &= \vec{k} \cdot \overrightarrow{AC_S}
 \end{aligned}
 $$
 

--- a/cours/06-problemes-classiques/homework-03.ipynb
+++ b/cours/06-problemes-classiques/homework-03.ipynb
@@ -192,7 +192,8 @@
     "Dans le TP 9, vous avez implémenté une bibliothèque de fonctions de manipulation d'une liste chaînée. Vous allez compléter cette bibliothèque en ajoutant des fonctions de gestion d'ensembles.\n",
     "\n",
     "*Astuces* :\n",
-    "* Vous pouvez créer une fonction `creer_liste_python` qui transforme une liste chaînée en une liste python :\n",
+    "\n",
+    "- Vous pouvez créer une fonction `creer_liste_python` qui transforme une liste chaînée en une liste python :\n",
     "\n",
     "```py\n",
     "def creer_liste_python(L):\n",
@@ -210,16 +211,16 @@
     "print(liste)\n",
     "```\n",
     "\n",
-    "* Vous pouvez utiliser la fonction `creer_liste_chainee` de la manière suivante :\n",
+    "- Vous pouvez utiliser la fonction `creer_liste_chainee` de la manière suivante :\n",
     "\n",
     "```py\n",
     "L2 = creer_liste_chainee(*liste) # 1 → 2 → 3\n",
     "affiche_liste(L2)\n",
     "```\n",
     "\n",
-    "* Ainsi, vous pouvez utiliser temporairement des listes Python pour effectuer vos opérations d'union, intersection et exclusion plus facilement.\n",
-    "* Une fois que vous avez terminé vos opérations avec des listes Python, vous pouvez convertir le résultat en une liste chaînée.\n",
-    "* Insérer ici le code que vous avez écrit dans le cadre du TP 9."
+    "- Ainsi, vous pouvez utiliser temporairement des listes Python pour effectuer vos opérations d'union, intersection et exclusion plus facilement.\n",
+    "- Une fois que vous avez terminé vos opérations avec des listes Python, vous pouvez convertir le résultat en une liste chaînée.\n",
+    "- Insérer ici le code que vous avez écrit dans le cadre du TP 9."
    ]
   },
   {
@@ -380,8 +381,9 @@
     "### Exercice 4.2 - Matrices triangulaires (2 points)\n",
     "\n",
     "Il existe 2 types de matrices triangulaires :\n",
-    "* Les matrices triangulaires supérieures, dont tous les éléments sous la diagonale sont égaux à 0.\n",
-    "* Les matrices triangulaires inférieures, dont tous les éléments au-dessus de la diagonale sont égaux à 0.\n",
+    "\n",
+    "- Les matrices triangulaires supérieures, dont tous les éléments sous la diagonale sont égaux à 0.\n",
+    "- Les matrices triangulaires inférieures, dont tous les éléments au-dessus de la diagonale sont égaux à 0.\n",
     "\n",
     "Par exemple :\n",
     "\n",
@@ -628,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.9"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Jupyter comes in with a nice CLI that may perform conversions of a
Notebook to various formats, including HTML and PDF. This conver-
-sion should ideally be automated at build time so that the work
assignments would be readily available in a web browser with nothing
to install (since most undergrads struggle with VSCode or Binder).

However, Jupyter uses a stricter parser. Thus, some code accepted
by VSCode and Binder may lead to issues when using Jupyter directly.

In particular, Markdown bullet points and LaTeX maths formulas are
parsed with a different engine that does not interpret them in the
same fashion.

```bash
jupyter nbconvert --to pdf homework-03.ipynb

jupyter nbconvert --to latex homework-03.ipynb
```

Then add the following snippet at the beginning of the article, just
after the 1st line:

```latex
\usepackage[utf8]{inputenc}
\usepackage[french,english]{babel}
```

You may also change the `\title` and add `\date{}` to remove the date
that appears by default as a subtitle.

Finally, use LaTeX (or XeLaTeX) to generate the PDF.